### PR TITLE
Feature/private ssh key

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -40,3 +40,8 @@ variable "ansible_force_run" {
   default     = false
   description = "Run Ansible on every Terraform apply"
 }
+
+variable "bootstrap_ssh_private_key" {
+  default     = ""
+  description = "SSH Private key to be used ( default use SSH_Agent)"
+}


### PR DESCRIPTION
adding private key usage. This feature is more meant for testing purpose having terraform generating an SSH key.

For production usage its more secure to use ssh-agent as the private key will be placed on bootstrap node.